### PR TITLE
fix active url with query in navigation

### DIFF
--- a/packages/client/src/routes.ts
+++ b/packages/client/src/routes.ts
@@ -3,8 +3,12 @@ import type { IRoutes, Paths } from '@guild-docs/types';
 /**
  * Compare function designed to ignore trailing slashes when comparing paths
  */
-export function arePathnamesEqual(a: string, b: string) {
-  return withTrailingSlash(a) === withTrailingSlash(b);
+export function arePathnamesEqual(a: string, b: string): boolean {
+  return withTrailingSlash(withoutUrlQuery(a)) === withTrailingSlash(withoutUrlQuery(b));
+}
+
+export function withoutUrlQuery(v: string): string {
+  return v.split('#')[0]!;
 }
 
 export function withTrailingSlash(v: string) {


### PR DESCRIPTION
you can see this issue opening this URL: https://the-guild-docs-git-tgc-integration-theguild.vercel.app/docs#heading-3

vs https://the-guild-docs-git-psz-tgc-integration-theguild.vercel.app/docs#heading-3