### PR TITLE
chore: fix this weird thing that does not fail within the example app…

### DIFF
--- a/.changeset/empty-walls-tickle.md
+++ b/.changeset/empty-walls-tickle.md
@@ -1,0 +1,14 @@
+---
+'@guild-docs/client': patch
+---
+
+fix this weird thing that does not cause any runtime errors within the example app in this repo but breaks graphql-yoga.
+
+**Original error**
+
+```
+Unhandled Runtime Error
+Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.
+
+Check the render method of `Pagination`.
+```

--- a/packages/client/src/components/pagination.tsx
+++ b/packages/client/src/components/pagination.tsx
@@ -1,5 +1,8 @@
-import NextLink from 'next/link.js';
+import NextLinkImport from 'next/link.js';
 import React, { CSSProperties, ReactElement } from 'react';
+import { getDefault } from '../utils';
+
+const NextLink = getDefault(NextLinkImport);
 
 type PaginationProps = {
   previous?: { path: string; title: string };


### PR DESCRIPTION
… in this repo but breaks graphql-yoga (Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.)